### PR TITLE
Add a redis cache client and wrapper

### DIFF
--- a/app/cache/redis_wrapper.py
+++ b/app/cache/redis_wrapper.py
@@ -1,0 +1,47 @@
+import json
+from redis import Redis
+from typing import Optional, Dict, Any
+from app.core.config import settings
+
+# Cliente de Redis inicializado desde la URL de configuración.
+redis_client = Redis.from_url(settings.REDIS_URL, decode_responses=True)
+
+class CacheWrapper:
+    """
+    Redis cache client and wrapper for the Article service.
+
+    This module provides a lightweight abstraction layer over Redis,
+    offering helper methods to cache, retrieve, and invalidate article data.
+    It ensures consistent key naming, JSON serialization, and time-to-live (TTL)
+    management based on the application settings.
+
+    Attributes:
+        redis_client (Redis):
+            A global Redis client instance initialized using the configured URL.
+
+    Classes:
+        CacheWrapper:
+            Provides simple methods for interacting with Redis, including:
+                - get(article_id): Retrieve a cached article by ID.
+                - set(article_id, data): Store an article with a defined TTL.
+                - invalidate(article_id): Remove a cached article by ID.
+
+    """
+    @staticmethod
+    def _get_article_key(article_id: int) -> str:
+        return f"article:{article_id}"
+
+    def get(self, article_id: int) -> Optional[Dict[str, Any]]:
+        key = self._get_article_key(article_id)
+        cached_data = redis_client.get(key)
+        if cached_data:
+            return json.loads(cached_data)
+        return None
+
+    def set(self, article_id: int, data: Dict[str, Any]) -> None:
+        key = self._get_article_key(article_id)
+        redis_client.set(key, json.dumps(data, default=str), ex=settings.CACHE_TTL_SECONDS)
+
+    def invalidate(self, article_id: int) -> None:
+        key = self._get_article_key(article_id)
+        redis_client.delete(key)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -31,17 +31,16 @@ class Article(Base):
     """
     __tablename__ = "articles"
 
-    id = Column(Integer, primary_key=True, index=True) [cite: 90]
-    title = Column(String(255), nullable=False) [cite: 91]
-    author = Column(String(150), nullable=False) [cite: 91, 94]
-    body = Column(Text, nullable=False) [cite: 92]
-    tags = Column(String, nullable=True) # Almacenado como string separado por ';' 
-    published_at = Column(DateTime, nullable=True) [cite: 95]
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False) [cite: 96]
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False) [cite: 96]
-
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(255), nullable=False)
+    author = Column(String(150), nullable=False)
+    body = Column(Text, nullable=False)
+    tags = Column(String, nullable=True)
+    published_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
     __table_args__ = (
-        UniqueConstraint("title", "author", name="uix_title_author"), [cite: 91, 97]
-        Index("ix_articles_author", "author"), [cite: 97]
-        Index("ix_articles_published_at", "published_at"), [cite: 97]
+        UniqueConstraint("title", "author", name="uix_title_author"),
+        Index("ix_articles_author", "author"),
+        Index("ix_articles_published_at", "published_at"),
     )


### PR DESCRIPTION
Redis cache client and wrapper for the Article service.

    This module provides a lightweight abstraction layer over Redis,
    offering helper methods to cache, retrieve, and invalidate article data.
    It ensures consistent key naming, JSON serialization, and time-to-live (TTL)
    management based on the application settings.